### PR TITLE
feat: canvas renderer

### DIFF
--- a/src/components/GameCanvas.svelte
+++ b/src/components/GameCanvas.svelte
@@ -1,0 +1,57 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { game } from '../lib/stores/gameStore';
+  import { clearCanvas, drawGrid, drawBoard, drawPiece, drawGhost } from '../lib/renderer/canvas';
+  import { BOARD_COLS, BOARD_ROWS, CELL_SIZE } from '../lib/game/constants';
+
+  const WIDTH = BOARD_COLS * CELL_SIZE;
+  const HEIGHT = BOARD_ROWS * CELL_SIZE;
+
+  let canvas: HTMLCanvasElement;
+  let animId: number;
+
+  function render() {
+    const ctx = canvas?.getContext('2d');
+    if (!ctx) return;
+    const state = $game;
+    clearCanvas(ctx, WIDTH, HEIGHT);
+    drawGrid(ctx);
+    drawBoard(ctx, state.board);
+    if (state.ghost) drawGhost(ctx, state.ghost);
+    if (state.active) drawPiece(ctx, state.active);
+  }
+
+  function handleKey(e: KeyboardEvent) {
+    if (['ArrowLeft','ArrowRight','ArrowDown','ArrowUp','Space','KeyC','KeyP'].includes(e.code)) {
+      e.preventDefault();
+    }
+    const status = $game.status;
+    if ((status === 'idle' || status === 'gameover') && e.code === 'Space') {
+      game.start();
+      return;
+    }
+    if (e.code === 'KeyP') { game.pause(); return; }
+    if (status !== 'playing') return;
+    if (e.code === 'ArrowLeft') game.moveLeft();
+    else if (e.code === 'ArrowRight') game.moveRight();
+    else if (e.code === 'ArrowDown') game.softDrop();
+    else if (e.code === 'ArrowUp') game.rotateCW();
+    else if (e.code === 'Space') game.hardDrop();
+    else if (e.code === 'KeyC') game.hold();
+  }
+
+  onMount(() => {
+    window.addEventListener('keydown', handleKey);
+    const unsubscribe = game.subscribe(() => {
+      cancelAnimationFrame(animId);
+      animId = requestAnimationFrame(render);
+    });
+    return () => {
+      window.removeEventListener('keydown', handleKey);
+      unsubscribe();
+      cancelAnimationFrame(animId);
+    };
+  });
+</script>
+
+<canvas bind:this={canvas} width={WIDTH} height={HEIGHT} style="display:block;" />

--- a/src/components/GameOverlay.svelte
+++ b/src/components/GameOverlay.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+  import { game } from '../lib/stores/gameStore';
+  $: status = $game.status;
+</script>
+
+{#if status === 'idle'}
+  <div class="overlay">
+    <div class="title">TETRIS</div>
+    <div class="hint">Press SPACE to start</div>
+  </div>
+{:else if status === 'paused'}
+  <div class="overlay">
+    <div class="title">PAUSED</div>
+    <div class="hint">Press P to resume</div>
+  </div>
+{:else if status === 'gameover'}
+  <div class="overlay">
+    <div class="title">GAME OVER</div>
+    <div class="hint">Press SPACE to restart</div>
+  </div>
+{/if}
+
+<style>
+  .overlay {
+    position: absolute; inset: 0;
+    display: flex; flex-direction: column;
+    align-items: center; justify-content: center;
+    background: rgba(0,0,0,0.7); gap: 12px;
+  }
+  .title { font-size: 32px; font-weight: bold; color: #e2e8f0; letter-spacing: 4px; }
+  .hint { font-size: 14px; color: #94a3b8; }
+</style>

--- a/src/components/HoldPiece.svelte
+++ b/src/components/HoldPiece.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+  import { afterUpdate } from 'svelte';
+  import { game } from '../lib/stores/gameStore';
+  import { drawMiniPiece } from '../lib/renderer/canvas';
+
+  const SIZE = 72;
+  let canvas: HTMLCanvasElement | undefined;
+
+  $: held = $game.held;
+  $: canHold = $game.canHold;
+
+  afterUpdate(() => {
+    const ctx = canvas?.getContext('2d');
+    if (ctx) {
+      if (held) {
+        drawMiniPiece(ctx, held, SIZE, SIZE);
+        if (!canHold) {
+          ctx.fillStyle = 'rgba(0,0,0,0.5)';
+          ctx.fillRect(0, 0, SIZE, SIZE);
+        }
+      } else {
+        ctx.clearRect(0, 0, SIZE, SIZE);
+        ctx.fillStyle = '#111827';
+        ctx.fillRect(0, 0, SIZE, SIZE);
+      }
+    }
+  });
+</script>
+
+<div class="hold-wrap">
+  <div class="label">HOLD</div>
+  <canvas bind:this={canvas} width={SIZE} height={SIZE} />
+</div>
+
+<style>
+  .hold-wrap { display:flex; flex-direction:column; gap:4px; align-items:center; }
+  .label { font-size:11px; color:#64748b; letter-spacing:1px; margin-bottom:4px; }
+  canvas { border-radius:4px; }
+</style>

--- a/src/components/NextPiece.svelte
+++ b/src/components/NextPiece.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+  import { afterUpdate } from 'svelte';
+  import { game } from '../lib/stores/gameStore';
+  import { drawMiniPiece } from '../lib/renderer/canvas';
+
+  const SIZE = 72;
+  let canvases: (HTMLCanvasElement | undefined)[] = [];
+
+  $: next = $game.next;
+
+  afterUpdate(() => {
+    for (let i = 0; i < next.length; i++) {
+      const ctx = canvases[i]?.getContext('2d');
+      if (ctx && next[i]) drawMiniPiece(ctx, next[i], SIZE, SIZE);
+    }
+  });
+</script>
+
+<div class="next-wrap">
+  <div class="label">NEXT</div>
+  {#each next as _type, i}
+    <canvas bind:this={canvases[i]} width={SIZE} height={SIZE} />
+  {/each}
+</div>
+
+<style>
+  .next-wrap { display:flex; flex-direction:column; gap:4px; align-items:center; }
+  .label { font-size:11px; color:#64748b; letter-spacing:1px; margin-bottom:4px; }
+  canvas { border-radius:4px; }
+</style>

--- a/src/components/ScoreBoard.svelte
+++ b/src/components/ScoreBoard.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+  import { game } from '../lib/stores/gameStore';
+  $: state = $game;
+</script>
+
+<div class="scoreboard">
+  <div class="stat"><span class="label">SCORE</span><span class="value">{state.score}</span></div>
+  <div class="stat"><span class="label">LEVEL</span><span class="value">{state.level}</span></div>
+  <div class="stat"><span class="label">LINES</span><span class="value">{state.lines}</span></div>
+</div>
+
+<style>
+  .scoreboard {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    padding: 12px;
+    background: #1a1a2e;
+    border-radius: 6px;
+    min-width: 100px;
+  }
+  .stat { display: flex; flex-direction: column; gap: 2px; }
+  .label { font-size: 11px; color: #64748b; letter-spacing: 1px; }
+  .value { font-size: 22px; font-weight: bold; color: #e2e8f0; }
+</style>

--- a/src/lib/renderer/__tests__/canvas.test.ts
+++ b/src/lib/renderer/__tests__/canvas.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  PALETTE,
+  clearCanvas,
+  drawGrid,
+  drawBoard,
+  drawPiece,
+  drawGhost,
+  drawMiniPiece,
+} from '../canvas';
+import { BOARD_COLS, BOARD_ROWS, CELL_SIZE } from '../../game/constants';
+
+// Mock CanvasRenderingContext2D
+function makeCtx() {
+  return {
+    fillStyle: '',
+    strokeStyle: '',
+    lineWidth: 0,
+    globalAlpha: 1,
+    fillRect: vi.fn(),
+    strokeRect: vi.fn(),
+    clearRect: vi.fn(),
+    beginPath: vi.fn(),
+    moveTo: vi.fn(),
+    lineTo: vi.fn(),
+    stroke: vi.fn(),
+  } as unknown as CanvasRenderingContext2D;
+}
+
+describe('PALETTE', () => {
+  it('has all 7 tetromino types', () => {
+    for (const t of ['I','O','T','S','Z','J','L']) {
+      expect(PALETTE[t]).toBeTruthy();
+    }
+  });
+});
+
+describe('clearCanvas', () => {
+  it('calls fillRect with full dimensions', () => {
+    const ctx = makeCtx();
+    clearCanvas(ctx, 320, 640);
+    expect(ctx.fillRect).toHaveBeenCalledWith(0, 0, 320, 640);
+  });
+});
+
+describe('drawGrid', () => {
+  it('draws correct number of lines', () => {
+    const ctx = makeCtx();
+    drawGrid(ctx);
+    // BOARD_ROWS+1 horizontal + BOARD_COLS+1 vertical beginPath calls
+    expect(ctx.beginPath).toHaveBeenCalledTimes(BOARD_ROWS + 1 + BOARD_COLS + 1);
+  });
+});
+
+describe('drawBoard', () => {
+  it('draws filled cells only', () => {
+    const ctx = makeCtx();
+    const board: (string | null)[][] = Array.from({ length: BOARD_ROWS }, () =>
+      Array(BOARD_COLS).fill(null)
+    );
+    board[19][5] = 'I';
+    board[18][3] = 'T';
+    drawBoard(ctx, board as any);
+    // Each filled cell calls fillRect twice (body + highlight)
+    expect(ctx.fillRect).toHaveBeenCalledTimes(4);
+  });
+
+  it('skips empty cells', () => {
+    const ctx = makeCtx();
+    const board: (string | null)[][] = Array.from({ length: BOARD_ROWS }, () =>
+      Array(BOARD_COLS).fill(null)
+    );
+    drawBoard(ctx, board as any);
+    expect(ctx.fillRect).not.toHaveBeenCalled();
+  });
+});
+
+describe('drawPiece', () => {
+  it('draws each cell of the piece', () => {
+    const ctx = makeCtx();
+    const piece = { type: 'I', row: 0, col: 3, rotation: 0 as const };
+    drawPiece(ctx, piece);
+    // I piece has 4 cells, each 2 fillRect calls
+    expect(ctx.fillRect).toHaveBeenCalledTimes(8);
+  });
+});
+
+describe('drawGhost', () => {
+  it('draws ghost using strokeRect', () => {
+    const ctx = makeCtx();
+    const ghost = { type: 'T', row: 16, col: 3, rotation: 0 as const };
+    drawGhost(ctx, ghost);
+    // T piece has 4 cells => 4 strokeRect calls
+    expect(ctx.strokeRect).toHaveBeenCalledTimes(4);
+  });
+});
+
+describe('drawMiniPiece', () => {
+  it('clears canvas and fills cells', () => {
+    const ctx = makeCtx();
+    drawMiniPiece(ctx, 'O', 72, 72);
+    expect(ctx.clearRect).toHaveBeenCalledWith(0, 0, 72, 72);
+    // O has 4 cells, each 2 fillRect + 1 background fillRect = 9 total
+    expect(ctx.fillRect).toHaveBeenCalled();
+  });
+
+  it('handles unknown type gracefully', () => {
+    const ctx = makeCtx();
+    expect(() => drawMiniPiece(ctx, 'X', 72, 72)).not.toThrow();
+  });
+});

--- a/src/lib/renderer/canvas.ts
+++ b/src/lib/renderer/canvas.ts
@@ -1,0 +1,110 @@
+import { BOARD_COLS, BOARD_ROWS, CELL_SIZE } from '../game/constants';
+import type { Board } from '../game/board';
+import type { ActivePiece } from '../game/tetromino';
+import { getCells } from '../game/tetromino';
+
+export const PALETTE: Record<string, string> = {
+  I: '#00f0f0',
+  O: '#f0f000',
+  T: '#a000f0',
+  S: '#00f000',
+  Z: '#f00000',
+  J: '#0000f0',
+  L: '#f0a000',
+  empty: '#111827',
+  ghost: '#334155',
+  grid: '#1f2937',
+};
+
+export function clearCanvas(ctx: CanvasRenderingContext2D, width: number, height: number): void {
+  ctx.fillStyle = '#0d0d0d';
+  ctx.fillRect(0, 0, width, height);
+}
+
+export function drawGrid(ctx: CanvasRenderingContext2D): void {
+  ctx.strokeStyle = PALETTE.grid;
+  ctx.lineWidth = 0.5;
+  for (let r = 0; r <= BOARD_ROWS; r++) {
+    ctx.beginPath();
+    ctx.moveTo(0, r * CELL_SIZE);
+    ctx.lineTo(BOARD_COLS * CELL_SIZE, r * CELL_SIZE);
+    ctx.stroke();
+  }
+  for (let c = 0; c <= BOARD_COLS; c++) {
+    ctx.beginPath();
+    ctx.moveTo(c * CELL_SIZE, 0);
+    ctx.lineTo(c * CELL_SIZE, BOARD_ROWS * CELL_SIZE);
+    ctx.stroke();
+  }
+}
+
+export function drawBoard(ctx: CanvasRenderingContext2D, board: Board): void {
+  for (let r = 0; r < BOARD_ROWS; r++) {
+    for (let c = 0; c < BOARD_COLS; c++) {
+      const cell = board[r][c];
+      if (cell) {
+        drawCell(ctx, r, c, PALETTE[cell] ?? '#ffffff');
+      }
+    }
+  }
+}
+
+function drawCell(ctx: CanvasRenderingContext2D, row: number, col: number, color: string): void {
+  ctx.fillStyle = color;
+  ctx.fillRect(col * CELL_SIZE + 1, row * CELL_SIZE + 1, CELL_SIZE - 2, CELL_SIZE - 2);
+  ctx.fillStyle = 'rgba(255,255,255,0.2)';
+  ctx.fillRect(col * CELL_SIZE + 1, row * CELL_SIZE + 1, CELL_SIZE - 2, 3);
+}
+
+export function drawPiece(ctx: CanvasRenderingContext2D, piece: ActivePiece): void {
+  ctx.globalAlpha = 1;
+  for (const [r, c] of getCells(piece)) {
+    if (r >= 0) {
+      drawCell(ctx, r, c, PALETTE[piece.type] ?? '#ffffff');
+    }
+  }
+}
+
+export function drawGhost(ctx: CanvasRenderingContext2D, ghost: ActivePiece): void {
+  ctx.globalAlpha = 1;
+  for (const [r, c] of getCells(ghost)) {
+    if (r >= 0) {
+      ctx.strokeStyle = PALETTE[ghost.type] ?? '#ffffff';
+      ctx.lineWidth = 1;
+      ctx.strokeRect(c * CELL_SIZE + 2, r * CELL_SIZE + 2, CELL_SIZE - 4, CELL_SIZE - 4);
+    }
+  }
+}
+
+const MINI_CELL = 16;
+
+const MINI_SHAPES: Record<string, [number, number][]> = {
+  I: [[1,0],[1,1],[1,2],[1,3]],
+  O: [[1,1],[1,2],[2,1],[2,2]],
+  T: [[1,1],[2,0],[2,1],[2,2]],
+  S: [[1,1],[1,2],[2,0],[2,1]],
+  Z: [[1,0],[1,1],[2,1],[2,2]],
+  J: [[1,0],[2,0],[2,1],[2,2]],
+  L: [[1,2],[2,0],[2,1],[2,2]],
+};
+
+export function drawMiniPiece(
+  ctx: CanvasRenderingContext2D,
+  type: string,
+  canvasWidth: number,
+  canvasHeight: number
+): void {
+  const cells = MINI_SHAPES[type] ?? [];
+  const color = PALETTE[type] ?? '#888';
+  const offsetX = Math.floor((canvasWidth - 4 * MINI_CELL) / 2);
+  const offsetY = Math.floor((canvasHeight - 4 * MINI_CELL) / 2);
+  ctx.clearRect(0, 0, canvasWidth, canvasHeight);
+  ctx.fillStyle = '#111827';
+  ctx.fillRect(0, 0, canvasWidth, canvasHeight);
+  for (const [r, c] of cells) {
+    ctx.fillStyle = color;
+    ctx.fillRect(offsetX + c * MINI_CELL + 1, offsetY + r * MINI_CELL + 1, MINI_CELL - 2, MINI_CELL - 2);
+    ctx.fillStyle = 'rgba(255,255,255,0.2)';
+    ctx.fillRect(offsetX + c * MINI_CELL + 1, offsetY + r * MINI_CELL + 1, MINI_CELL - 2, 3);
+  }
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,3 +1,88 @@
+<script lang="ts">
+  import GameCanvas from '../components/GameCanvas.svelte';
+  import ScoreBoard from '../components/ScoreBoard.svelte';
+  import NextPiece from '../components/NextPiece.svelte';
+  import HoldPiece from '../components/HoldPiece.svelte';
+  import GameOverlay from '../components/GameOverlay.svelte';
+</script>
+
+<svelte:head>
+  <title>Tetris</title>
+</svelte:head>
+
 <main>
-  <h1>Tetris</h1>
+  <div class="game-layout">
+    <div class="left-panel">
+      <HoldPiece />
+      <ScoreBoard />
+    </div>
+
+    <div class="board-wrap">
+      <GameCanvas />
+      <GameOverlay />
+    </div>
+
+    <div class="right-panel">
+      <NextPiece />
+    </div>
+  </div>
+
+  <div class="controls">
+    <span>← → Move</span>
+    <span>↑ Rotate</span>
+    <span>↓ Soft drop</span>
+    <span>Space Hard drop</span>
+    <span>C Hold</span>
+    <span>P Pause</span>
+  </div>
 </main>
+
+<style>
+  :global(body) {
+    margin: 0;
+    background: #0f172a;
+    color: #e2e8f0;
+    font-family: 'Courier New', monospace;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 100vh;
+  }
+
+  main {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 16px;
+  }
+
+  .game-layout {
+    display: flex;
+    gap: 12px;
+    align-items: flex-start;
+  }
+
+  .board-wrap {
+    position: relative;
+    border: 2px solid #334155;
+    border-radius: 4px;
+    overflow: hidden;
+  }
+
+  .left-panel, .right-panel {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    align-items: center;
+    min-width: 90px;
+  }
+
+  .controls {
+    display: flex;
+    gap: 16px;
+    flex-wrap: wrap;
+    justify-content: center;
+    font-size: 12px;
+    color: #475569;
+  }
+</style>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,5 @@
 import { sveltekit } from '@sveltejs/kit/vite';
-import { defineConfig } from 'vite';
+import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   plugins: [sveltekit()],


### PR DESCRIPTION
Implements the canvas-based rendering pipeline for the Tetris game (closes #6).

## Changes
- `src/lib/renderer/canvas.ts` — core renderer: `clearCanvas`, `drawGrid`, `drawBoard`, `drawPiece`, `drawGhost`, `drawMiniPiece`
- `src/components/GameCanvas.svelte` — main board canvas, subscribed to `game` store, handles keyboard input
- `src/components/ScoreBoard.svelte` — score / level / lines display
- `src/components/NextPiece.svelte` — mini-canvas for upcoming pieces queue
- `src/components/HoldPiece.svelte` — mini-canvas for held piece with dim-when-unavailable effect
- `src/components/GameOverlay.svelte` — idle / paused / game-over overlay
- `src/routes/+page.svelte` — wires all components into game layout
- `src/lib/renderer/__tests__/canvas.test.ts` — 9 unit tests for renderer functions (mock ctx)

## Test results
- 36/36 tests passing (vitest)
